### PR TITLE
Fixes for Ubuntu 22

### DIFF
--- a/firmware/firmware.sh
+++ b/firmware/firmware.sh
@@ -11,10 +11,10 @@ cd firmware
 rm -f *.bin *.md5 *.md
 
 # for dev versions:
-gh release download latest -R emsesp/EMS-ESP32 --clobber
+gh release download latest -R emsesp/EMS-ESP32
 
 # for stable versions:
-gh release download -p "*" -R emsesp/EMS-ESP32 --clobber
+gh release download -p "*" -R emsesp/EMS-ESP32
 
 # don't need the changelog or the .md5 files
 rm -f *.md*

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -46,11 +46,13 @@ fi
 echo "* Checking if an ESP32 is connected to the COM port..."
 
 # connect using esptool, and replace all newlines with a pipe
-connect_info=$(python ./scripts/local_esptool.py $port_arg flash_id | tr -d '\r')
+connect_info=$(python ./scripts/local_esptool.py $port_arg flash_id)
+connect_error=$?
+connect_info=$(echo "$connect_info" | tr -d '\r')
 connect_info=${connect_info//[$'\r\n']/| }
 
 # check for errors
-if [[ $connect_info == *"error"* ]]; then
+if [[ $connect_error -ne 0 ]]; then
   echo ""
   echo "Failed to connect to ESP32. Exiting."
   echo ""
@@ -113,7 +115,7 @@ if [ ! -f $firmware_file ]; then
   exit 1
 fi
 
-# get current data
+# get current date
 current_date=$(date)
 
 # filename of firmware used


### PR DESCRIPTION
Here are the fixes I needed to make for this to run on my Ubuntu 22 installation:

1. The gh package for Ubuntu 22 seems to be at version 2.4.0+dfsg1 (2022-03-23 Ubuntu 2.4.0+dfsg1-2), which does not have the --clobber option used by firmware.sh. I think it can simply be omitted since the existing files are cleaned out via rm anyways.

2. The auto port selection didn't work as implemented because esptool outputs a lot of warnings during port detection that contain the word 'error', such as

		Serial port /dev/ttyS0
		/dev/ttyS0 failed to connect: Could not open /dev/ttyS0, the port is busy or doesn't exist.
		(Could not configure port: (5, 'Input/output error'))

   So I've switched to using the error code of esptool, which seems to work as intended.


BTW: the console check at the end doesn't do much for me (got only junk in console_capture.txt) but the firmware flashes and works just fine. :smiley: 